### PR TITLE
add compress parameter to the URL in order to choose the method

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,15 @@ func main() {
     c.Close()
 }
 ```
+
+You can use the query parameter "compress" in the Dial URL, with one of the following value:
+
+* none
+* zlib
+* gzip
+
+```
+udp://192.168.30.150?compress=none
+```
+
+Default is gzip compression.

--- a/client.go
+++ b/client.go
@@ -95,6 +95,15 @@ func (c *Client) Dial(uri string) error {
 		return errors.New("Unsupported scheme provided")
 	}
 
+	switch parsedUri.Query().Get("compress") {
+	case "none":
+		c.config.Compression = COMP_NONE
+	case "zlib":
+		c.config.Compression = COMP_ZLIB
+	case "gzip":
+		c.config.Compression = COMP_GZIP
+	}
+
 	conn, err := net.Dial(parsedUri.Scheme, parsedUri.Host)
 	if err != nil {
 		return err
@@ -195,7 +204,7 @@ func (c *Client) msgSender() {
 				// user can watch for errors
 				continue
 			}
-			err = c.writeMsg(data, c.conn, COMP_GZIP)
+			err = c.writeMsg(data, c.conn, c.config.Compression)
 			if err != nil {
 				// TODO Same as above...
 			}


### PR DESCRIPTION
I wanted to try other compression options so I added the compress parameter handling to the Dial URL, as the rest was pretty much already there.